### PR TITLE
Change hash bang to be portable across different systems

### DIFF
--- a/examples/crs_read.py
+++ b/examples/crs_read.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os, os.path

--- a/examples/crs_write.py
+++ b/examples/crs_write.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os, os.path

--- a/examples/example3_addtag.py
+++ b/examples/example3_addtag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import yaml

--- a/examples/example4_reduce_escs.py
+++ b/examples/example4_reduce_escs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import yaml

--- a/examples/example5_act_case_check.py
+++ b/examples/example5_act_case_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/examples/example6_act_order_check.py
+++ b/examples/example6_act_order_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/examples/example7_beautifier.py
+++ b/examples/example7_beautifier.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/examples/example7a_beautifier.py
+++ b/examples/example7a_beautifier.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/examples/example8_check_ver_act.py
+++ b/examples/example8_check_ver_act.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/examples/example9_collect_transforms.py
+++ b/examples/example9_collect_transforms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/examples/test_lexer.py
+++ b/examples/test_lexer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import msc_pyparser

--- a/examples/test_parser.py
+++ b/examples/test_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os


### PR DESCRIPTION
Update the hash bang line in the python scripts to use the python3 specified in the user's environment to increase portability (e.g., if someone uses `virtualenv` then the python3 binary would be in the virtualenv directory.)