### PR TITLE
Set 'oplineno' if operator implicit, fixes #12

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,10 @@
 v0.3 - YYYY-MM-DD
 -----------------
+  * Set the 'oplineno' argument in case of implicit operator,
+    eg. 'SecRule "foo"...' means 'SecRule "@rx foo"', oplineno need
+    fixes #12
   * Extended the parser with different syntax than CRS used.
-    This patterns were listed in issue 09, reported by @MirkoDziadzka
+    This patterns were listed in issue #09, reported by @MirkoDziadzka
   * Changed version number in README.md
   * Changed version in the given example (typo)
   * Add new example: example7a_beautifier.py, which places the `t` actions inline

--- a/msc_pyparser.py
+++ b/msc_pyparser.py
@@ -526,6 +526,7 @@ class MSCParser(object):
         """secoperator_arg_group : SECRULE_OPERATOR_ARG
                                 | NUMBER"""
         self.secrule['operator_argument'] = p[1]
+        self.secrule['oplineno'] = p.lineno(1)
 
     def p_secoperatorarg_noquote(self, p):
         """secoperatorarg_noquote : SECRULE_OPERATOR_ARG_NOQUOTE"""


### PR DESCRIPTION
Explicit set the `oplineno` argument if no SecOP presents, eg:
`SecRule "foo" ...` means `SecRule "@rx foo"` - `oplineno` member will set also.