### PR TITLE
Add some rulese for regression test

### DIFF
--- a/tests/regression.conf
+++ b/tests/regression.conf
@@ -1,0 +1,29 @@
+#
+# some rule extract from a bigger real-life ruleset which stress
+# different aspects of the lexer/parser
+#
+SecRule ARGS "@rx ^\\\\" "id:1001,phase:2,block,t:none"
+
+SecRule ARGS "@contains :" "id:1002,phase:2,block,t:none"
+
+SecRule ARGS "@pm |" "id:1003,phase:2,block,t:none"
+
+SecRule ARGS "@rx :\/" "id:1004,phase:2,block,t:none"
+
+SecRule ARGS,REQUEST_HEADERS "@rx 42" "id:1005,phase:2,block,t:none"
+
+SecRule ARGS foobar "id:1006,phase:2,block,t:none"
+
+SecRule REQUEST_URI|REQUEST_HEADERS "@rx 42" "id:1007,phase:2,block,t:none"
+
+SecRule REQUEST_URI,REQUEST_HEADERS "@rx 42" "id:1008,phase:2,block,t:none"
+
+SecRule ARGS:'/^(foo|bar)$/' "@rx 42" "id:1009,phase:2,block,t:none"
+
+SecRule ARGS:'/^(foo|bar)$/' "@rx 42" "id:1010,phase:2,block,tag:'hello',t:none"
+
+SecRule ARGS "@rx foo" "chain,id:1011,phase:2,block,t:none"
+	SecRule ARGS ".*" "t:none"
+
+SecRule ARGS "@rx #"  "id:1012,phase:2,block,t:none"
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,3 +21,16 @@ def test_parser(mparser, read_config_file):
 
     assert len(mparser.configlines) > 0
     assert mparser.secconfdir is not None
+
+
+def test_parser_regession(mparser, read_config_file):
+    """ make sure that we can parse the regression rules
+    """
+    modsec_rules = read_config_file("regression.conf")
+    mparser.parser.parse(modsec_rules)
+    parsed = mparser.configlines
+
+    rules = [entry for entry in parsed if entry.get("type") == "SecRule"]
+
+    assert len(rules) == 13, "we ecpect 13 rules"
+    assert rules[10]["chained"], "rule 11 (position 10) should be chained"


### PR DESCRIPTION
Add some rules which push the parser to the limit and which failed
in past versions.